### PR TITLE
prevented tensorflow override by baselines

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,20 @@ Our dependencies require Python 3.5 (and assume appropriate GPU drivers have alr
 
 Installing OpenAI baselines
 
-	git clone https://github.com/openai/baselines.git
-	cd baselines
-	sudo apt install -y mpich # see Mac OS version below
-	env MPICC=/usr/bin/mpicc pip install mpi4py	# see Mac OS version below
-	pip install --no-dependencies -e .
-	cd ..
+    git clone https://github.com/openai/baselines.git
+    cd baselines
+    git checkout 4993286230ac92ead39a66005b7042b56b8598b0
+    sudo apt install -y mpich # see Mac OS version below
+    env MPICC=/usr/bin/mpicc pip install mpi4py # see Mac OS version below
+    pip install --no-dependencies -e .
+    cd ..
 
-	## Mac OS
-	brew install mpich
-	env MPICC=/usr/local/Cellar/mpich/3.2_3/bin/mpicc pip install mpi4py
-	# (if that fails, use 'sudo find / -name mpicc' to find where MPICC is located + substitute accordingly)
+    ## Mac OS
+    brew install mpich
+    env MPICC=/usr/local/Cellar/mpich/3.2_3/bin/mpicc pip install mpi4py
+    # (if that fails, use 'sudo find / -name mpicc' to find where MPICC is located + substitute accordingly)
 
 Train PPO agent
 
-	cd src
-	python run_atari_ppo.py [--max_timesteps=1]
+    cd src
+    python run_atari_ppo.py [--max_timesteps=1]

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Installing OpenAI baselines
 
 	git clone https://github.com/openai/baselines.git
 	cd baselines
-	sudo apt-get install mpich 	# see Mac OS version below
+	sudo apt install -y mpich # see Mac OS version below
 	env MPICC=/usr/bin/mpicc pip install mpi4py	# see Mac OS version below
-	pip install -e .
+	pip install --no-dependencies -e .
 	cd ..
 
 	## Mac OS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,12 @@
 scipy
 numpy>=1.13
 mujoco_py==0.5.7
-gym[atari]
+gym[atari,mujoco,classic_control]
 opencv-python
 h5py
+tqdm
+joblib
+zmq
+dill
+azure==1.0.3
+progressbar2

--- a/src/atari_env.py
+++ b/src/atari_env.py
@@ -19,13 +19,14 @@ def _wrap_deepmind_ram(env):
     env = ClipRewardEnv(env)
     return env
 
-def wrap_train(env):
-    """Helper function."""
+def _wrap_deepmind(env, frame_stack=False):
+    """Analogous to _wrap_deepmind_ram, but for the original Atari env."""
     env = wrap_deepmind(env, clip_rewards=True)
-    env = FrameStack(env, 4)
+    if frame_stack:
+        env = FrameStack(env, 4)
     return env
 
-def gen_pong_env(seed):
+def gen_pong_env(seed, frame_stack=False):
     """Generate a pong environment, with all the bells and whistles."""
     benchmark = gym.benchmark_spec('Atari40M')
     task = benchmark.tasks[3]
@@ -35,7 +36,7 @@ def gen_pong_env(seed):
     env.seed(seed)
 
     # Can wrap in gym.wrappers.Monitor here if we want to record.
-    env = wrap_deepmind(env)
+    env = _wrap_deepmind(env, frame_stack)
     return env
 
 def gen_vectorized_pong_env(n):
@@ -48,6 +49,7 @@ def gen_vectorized_pong_env(n):
     task = benchmark.tasks[3]
 
     env_id = task.env_id
+    # TODO: wrap_deepmind -> _wrap_deepmind, see issue #21
     envs = [wrap_deepmind(gym.make(env_id)) for _ in range(n)]
     env = MultiprocessingEnv(envs)
 
@@ -60,5 +62,6 @@ def gen_pong_ram_env(seed):
     env = gym.make("Pong-ram-v0")
     env.seed(seed)
     # Can wrap in gym.wrappers.Monitor here if we want to record.
+    # TODO: frame_stack, see issue #21
     env = _wrap_deepmind_ram(env)
     return env

--- a/src/run_atari_ppo.py
+++ b/src/run_atari_ppo.py
@@ -57,7 +57,7 @@ def main():
     prsr.add_argument("--max_timesteps", type=int)
     args = prsr.parse_args()
 
-    
+
     train(num_frames=40e6, seed=args.seed,
           max_ts=args.max_timesteps, logdir=args.logdir)
 


### PR DESCRIPTION
installing baselines kills a GPU tensorflow install. this commit fixes that dependency override.

Be careful: if you installed baselines before it may be using CPU only because it killed TF earlier.

the fix is to uninstall tf, tf-gpu, and then install baselines (if you haven't already), install tf-gpu.

otherwise, after this fix, following README Instructions should leave your system in the correct state.